### PR TITLE
Update ref code to use the correct bot id header

### DIFF
--- a/zendeskApi.js
+++ b/zendeskApi.js
@@ -4,7 +4,7 @@ const config = require('./config');
 const marketplaceHeaders = {
   'X-Zendesk-Marketplace-Name': config.zendeskMarketplaceName,
   'X-Zendesk-Marketplace-Organization-Id': config.zendeskMarketplaceOrgId,
-  'X-Zendesk-Marketplace-App-Id': config.zendeskMarketplaceAppId,
+  'X-Zendesk-Marketplace-Bot-Id': config.zendeskMarketplaceAppId,
 };
 
 async function exchangeCode(code) {


### PR DESCRIPTION
Zendesk marketplace bots don't have an app ID, they have a bot ID instead. Updating the reference implementation to use the correct `X-Zendesk-Marketplace-Bot-Id` header, to match what's in the [developer docs](https://developer.zendesk.com/documentation/conversations/how-to-guides/building-a-marketplace-bot/#api-requirements).